### PR TITLE
Make batch size configurable

### DIFF
--- a/model_engine/train.py
+++ b/model_engine/train.py
@@ -13,7 +13,7 @@ class TrainingConfigProvider(object):
 
 
 class TrainingDataProvider(object):
-    def training_data(self, batch_size=None, split=None) -> Tuple[tf.data.Dataset, Optional[tf.data.Dataset]]:
+    def training_data(self, batch_size) -> Tuple[tf.data.Dataset, Optional[tf.data.Dataset]]:
         pass
 
 


### PR DESCRIPTION
Previously the batch size was a hardcoded leftover from pulling code out from OAI. Also removed an unused split feature on the data provider as there's no use case at the moment.